### PR TITLE
[Fix] Load .env relative to backend package

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for UV index aggregator."""

--- a/backend/app.py
+++ b/backend/app.py
@@ -3,21 +3,22 @@ from __future__ import annotations
 import asyncio
 import datetime as dt
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import pandas as pd
+from dotenv import load_dotenv
 from fastapi import FastAPI, Query
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
-import pandas as pd
-from dotenv import load_dotenv
 from timezonefinder import TimezoneFinder
 from zoneinfo import ZoneInfo
 
-from uv_providers.open_meteo import OpenMeteoProvider
-from uv_providers.openuv_stub import OpenUVProvider
-from uv_providers.weatherbit_stub import WeatherbitProvider
+from .uv_providers.open_meteo import OpenMeteoProvider
+from .uv_providers.openuv_stub import OpenUVProvider
+from .uv_providers.weatherbit_stub import WeatherbitProvider
 
-load_dotenv()
+load_dotenv(Path(__file__).resolve().parent / ".env")
 
 app = FastAPI(title="UV Index Aggregator", version="0.2.0")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,11 @@
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "backend"))
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-import app as app_module
-from app import cache_key, detect_tz
-from uv_providers.base import clamp_uv
+import backend.app as app_module
+from backend.app import cache_key, detect_tz
+from backend.uv_providers.base import clamp_uv
 
 
 def test_clamp_uv_none():


### PR DESCRIPTION
## Summary
Allow running the backend from the repo root by treating `backend` as a package and loading `.env` relative to it.

## Testing Done
- `ruff check .`
- `pytest tests`
- `uvicorn backend.app:app --port 8000` & `curl -s http://127.0.0.1:8000/providers`


------
https://chatgpt.com/codex/tasks/task_e_68a1f76002d08330890de3c4aaa668d5