### PR TITLE
[Fix] Update OpenWeatherMap provider to One Call API

### DIFF
--- a/backend/uv_providers/openweathermap.py
+++ b/backend/uv_providers/openweathermap.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import httpx
 import os
+from datetime import datetime, time
 from typing import Any, Dict, List
-from datetime import datetime, timedelta
+
+import httpx
 import pytz
 
 from .base import UVProvider, ProviderResult, clamp_uv
@@ -15,8 +16,10 @@ class OpenWeatherMapProvider(UVProvider):
     async def fetch(
         self, *, lat: float, lon: float, date: str, tz: str
     ) -> ProviderResult:
-        print(f"[DEBUG] {self.name}: Starting fetch for lat={lat}, lon={lon}, date={date}, tz={tz}")
-        
+        print(
+            f"[DEBUG] {self.name}: Starting fetch for lat={lat}, lon={lon}, date={date}, tz={tz}"
+        )
+
         api_key = os.getenv("OPENWEATHERMAP_API_KEY")
         if not api_key:
             print(f"[DEBUG] {self.name}: No API key found, returning disabled error")
@@ -26,58 +29,131 @@ class OpenWeatherMapProvider(UVProvider):
                 hourly=[],
                 error="disabled (no OPENWEATHERMAP_API_KEY)",
             )
-        
-        # OpenWeatherMap UV Index API provides current and forecast data
-        # We'll use the forecast endpoint which gives UV index for the next 8 days
+
+        # OpenWeatherMap deprecated the dedicated UV API. Use the One Call
+        # endpoint which returns hourly data including UV index values.
         try:
-            url = f"https://api.openweathermap.org/data/2.5/uvi/forecast?lat={lat}&lon={lon}&appid={api_key}"
-            print(f"[DEBUG] {self.name}: Making request to URL: {url}")
-            
+            url_primary = "https://api.openweathermap.org/data/3.0/onecall"
+            url_fallback = "https://api.openweathermap.org/data/2.5/onecall"
+            params = {
+                "lat": lat,
+                "lon": lon,
+                "appid": api_key,
+                # We only need hourly/daily/current blocks; omit minutely & alerts
+                "exclude": "minutely,alerts",
+            }
+            print(
+                f"[DEBUG] {self.name}: Making request to URL: {url_primary} with params: {params}"
+            )
+
+            try:
+                target_tz = pytz.timezone(tz)
+            except Exception:
+                target_tz = pytz.UTC
+
             async with httpx.AsyncClient(timeout=20) as client:
-                r = await client.get(url)
-                r.raise_for_status()
-                data = r.json()
-            
-            print(f"[DEBUG] {self.name}: Received response with status {r.status_code}")
-            print(f"[DEBUG] {self.name}: Response data length: {len(data) if isinstance(data, list) else 'not a list'}")
-            
-            hourly: List[Dict[str, Any]] = []
-            target_date = datetime.strptime(date, "%Y-%m-%d").date()
-            print(f"[DEBUG] {self.name}: Looking for data for target date: {target_date}")
-            
-            for item in data:
-                # OpenWeatherMap returns unix timestamp
-                dt = datetime.fromtimestamp(item.get("date", 0), tz=pytz.UTC)
-                if dt.date() == target_date:
-                    # Convert to ISO format for consistency
-                    time_str = dt.isoformat().replace("+00:00", "Z")
-                    uv_value = item.get("value", 0)
-                    hourly.append({
-                        "time": time_str,
-                        "uv": clamp_uv(uv_value)
-                    })
-            
-            print(f"[DEBUG] {self.name}: Found {len(hourly)} matching data points for target date")
-            
-            # If we don't have hourly data, try to get at least one point for the day
-            if not hourly:
-                print(f"[DEBUG] {self.name}: No forecast data found, trying current UV endpoint")
-                # Fallback: use current UV index if available for the target date
-                current_url = f"https://api.openweathermap.org/data/2.5/uvi?lat={lat}&lon={lon}&appid={api_key}"
-                print(f"[DEBUG] {self.name}: Making fallback request to: {current_url}")
-                r_current = await client.get(current_url)
-                if r_current.status_code == 200:
-                    current_data = r_current.json()
-                    current_uv = current_data.get("value", 0)
-                    print(f"[DEBUG] {self.name}: Got current UV value: {current_uv}")
-                    # Add a single point at noon for the requested date
-                    hourly.append({
-                        "time": f"{date}T12:00:00Z",
-                        "uv": clamp_uv(current_uv)
-                    })
-                else:
-                    print(f"[DEBUG] {self.name}: Fallback request failed with status {r_current.status_code}")
-            
+                data = None
+
+                try:
+                    r = await client.get(url_primary, params=params)
+                    r.raise_for_status()
+                    data = r.json()
+                    print(
+                        f"[DEBUG] {self.name}: Received response with status {r.status_code}"
+                    )
+                except httpx.HTTPStatusError as exc:
+                    print(
+                        f"[DEBUG] {self.name}: Primary endpoint failed with status"
+                        f" {exc.response.status_code}: {exc}"
+                    )
+                    if exc.response.status_code in {400, 401, 403, 404}:
+                        print(
+                            f"[DEBUG] {self.name}: Retrying with fallback URL: {url_fallback}"
+                        )
+                        r = await client.get(url_fallback, params=params)
+                        r.raise_for_status()
+                        data = r.json()
+                        print(
+                            f"[DEBUG] {self.name}: Fallback response status {r.status_code}"
+                        )
+                    else:
+                        raise
+
+                if data is None:
+                    raise RuntimeError("No data retrieved from OpenWeatherMap")
+
+                hourly: List[Dict[str, Any]] = []
+                target_date = datetime.strptime(date, "%Y-%m-%d").date()
+                print(
+                    f"[DEBUG] {self.name}: Looking for hourly data for target date: {target_date}"
+                )
+
+                for item in data.get("hourly", []):
+                    dt_utc = datetime.fromtimestamp(item.get("dt", 0), tz=pytz.UTC)
+                    dt_local = dt_utc.astimezone(target_tz)
+                    if dt_local.date() != target_date:
+                        continue
+                    uv_value = item.get("uvi")
+                    if uv_value is None:
+                        continue
+                    hourly.append(
+                        {
+                            "time": dt_utc.isoformat().replace("+00:00", "Z"),
+                            "uv": clamp_uv(uv_value),
+                        }
+                    )
+
+                print(
+                    f"[DEBUG] {self.name}: Found {len(hourly)} matching hourly data points"
+                )
+
+                if not hourly:
+                    print(
+                        f"[DEBUG] {self.name}: No hourly data for date, checking daily summary"
+                    )
+                    for item in data.get("daily", []):
+                        dt_utc = datetime.fromtimestamp(item.get("dt", 0), tz=pytz.UTC)
+                        dt_local = dt_utc.astimezone(target_tz)
+                        if dt_local.date() != target_date:
+                            continue
+                        uv_value = item.get("uvi")
+                        if uv_value is None:
+                            continue
+                        noon_naive = datetime.combine(target_date, time(12, 0))
+                        if hasattr(target_tz, "localize"):
+                            noon_local = target_tz.localize(noon_naive)
+                        else:
+                            noon_local = noon_naive.replace(tzinfo=target_tz)
+                        noon_utc = noon_local.astimezone(pytz.UTC)
+                        hourly.append(
+                            {
+                                "time": noon_utc.isoformat().replace("+00:00", "Z"),
+                                "uv": clamp_uv(uv_value),
+                            }
+                        )
+                        break
+
+                if not hourly and data.get("current"):
+                    print(
+                        f"[DEBUG] {self.name}: Falling back to current UV value for date"
+                    )
+                    current = data["current"]
+                    current_uv = current.get("uvi")
+                    if current_uv is not None:
+                        current_dt_utc = datetime.fromtimestamp(
+                            current.get("dt", 0), tz=pytz.UTC
+                        )
+                        current_dt_local = current_dt_utc.astimezone(target_tz)
+                        if current_dt_local.date() == target_date:
+                            hourly.append(
+                                {
+                                    "time": current_dt_utc.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "uv": clamp_uv(current_uv),
+                                }
+                            )
+
             result = ProviderResult(name=self.name, tz=tz, hourly=hourly)
             print(f"[DEBUG] {self.name}: Returning {len(hourly)} hourly data points")
             return result

--- a/tests/test_openweathermap_provider.py
+++ b/tests/test_openweathermap_provider.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, List
+
+import httpx
+import pytz
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+OpenWeatherMapProvider = importlib.import_module(
+    "backend.uv_providers.openweathermap"
+).OpenWeatherMapProvider
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.request = None
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            response = httpx.Response(
+                status_code=self.status_code,
+                request=self.request,
+            )
+            raise httpx.HTTPStatusError(
+                message=f"HTTP {self.status_code}",
+                request=self.request,
+                response=response,
+            )
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeAsyncClient:
+    def __init__(
+        self, responses: Iterable[FakeResponse], *args: Any, **kwargs: Any
+    ) -> None:
+        self._responses: List[FakeResponse] = list(responses)
+
+    async def __aenter__(self) -> "FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+    async def get(self, url: str, params=None) -> FakeResponse:  # type: ignore[override]
+        if not self._responses:
+            raise AssertionError("No more fake responses configured")
+        response = self._responses.pop(0)
+        response.request = httpx.Request("GET", url, params=params)
+        return response
+
+
+def run_fetch(provider: OpenWeatherMapProvider, **kwargs: Any):
+    return asyncio.run(provider.fetch(**kwargs))
+
+
+def test_fetch_uses_hourly_data(monkeypatch):
+    monkeypatch.setenv("OPENWEATHERMAP_API_KEY", "dummy")
+
+    timestamp = int(datetime(2023, 10, 1, 9, tzinfo=pytz.UTC).timestamp())
+    responses = [
+        FakeResponse(
+            200,
+            {
+                "hourly": [{"dt": timestamp, "uvi": 5.0}],
+                "daily": [],
+                "current": {},
+            },
+        )
+    ]
+
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: FakeAsyncClient(responses, *args, **kwargs),
+    )
+
+    provider = OpenWeatherMapProvider()
+    result = run_fetch(
+        provider,
+        lat=1.0,
+        lon=2.0,
+        date="2023-10-01",
+        tz="UTC",
+    )
+
+    assert result["hourly"] == [{"time": "2023-10-01T09:00:00Z", "uv": 5.0}]
+
+
+def test_daily_fallback_when_hourly_missing(monkeypatch):
+    monkeypatch.setenv("OPENWEATHERMAP_API_KEY", "dummy")
+
+    timestamp = int(datetime(2023, 10, 1, 16, tzinfo=pytz.UTC).timestamp())
+    responses = [
+        FakeResponse(
+            200,
+            {
+                "hourly": [],
+                "daily": [{"dt": timestamp, "uvi": 6.5}],
+                "current": {},
+            },
+        )
+    ]
+
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: FakeAsyncClient(responses, *args, **kwargs),
+    )
+
+    provider = OpenWeatherMapProvider()
+    result = run_fetch(
+        provider,
+        lat=40.0,
+        lon=-73.0,
+        date="2023-10-01",
+        tz="America/New_York",
+    )
+
+    assert result["hourly"] == [{"time": "2023-10-01T16:00:00Z", "uv": 6.5}]
+
+
+def test_current_fallback_when_no_hourly_or_daily(monkeypatch):
+    monkeypatch.setenv("OPENWEATHERMAP_API_KEY", "dummy")
+
+    timestamp = int(datetime(2023, 10, 1, 12, tzinfo=pytz.UTC).timestamp())
+    responses = [
+        FakeResponse(
+            200,
+            {
+                "hourly": [],
+                "daily": [],
+                "current": {"dt": timestamp, "uvi": 3.2},
+            },
+        )
+    ]
+
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: FakeAsyncClient(responses, *args, **kwargs),
+    )
+
+    provider = OpenWeatherMapProvider()
+    result = run_fetch(
+        provider,
+        lat=10.0,
+        lon=20.0,
+        date="2023-10-01",
+        tz="UTC",
+    )
+
+    assert result["hourly"] == [{"time": "2023-10-01T12:00:00Z", "uv": 3.2}]
+
+
+def test_fallback_to_legacy_endpoint(monkeypatch):
+    monkeypatch.setenv("OPENWEATHERMAP_API_KEY", "dummy")
+
+    timestamp = int(datetime(2023, 10, 1, 9, tzinfo=pytz.UTC).timestamp())
+    responses = [
+        FakeResponse(404, {}),
+        FakeResponse(
+            200,
+            {
+                "hourly": [{"dt": timestamp, "uvi": 4.4}],
+                "daily": [],
+                "current": {},
+            },
+        ),
+    ]
+
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: FakeAsyncClient(responses, *args, **kwargs),
+    )
+
+    provider = OpenWeatherMapProvider()
+    result = run_fetch(
+        provider,
+        lat=1.0,
+        lon=2.0,
+        date="2023-10-01",
+        tz="UTC",
+    )
+
+    assert result["hourly"] == [{"time": "2023-10-01T09:00:00Z", "uv": 4.4}]


### PR DESCRIPTION
One-line summary: Switch OpenWeatherMap provider to the One Call API with robust fallbacks and coverage.

Testing Done:
- ✅ `ruff check backend/uv_providers/openweathermap.py tests/test_openweathermap_provider.py`
- ✅ `pytest tests/test_openweathermap_provider.py -q`
- ⚠️ `pytest tests/ -q` *(fails: ModuleNotFoundError: No module named 'uv_providers')*

------
https://chatgpt.com/codex/tasks/task_e_68cd7fbfcc6883308146619ef61cb213