### PR TITLE
[Fix] Add Playwright demo recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ uvicorn app:app --reload
 
 Open `frontend/index.html` in your browser and click **Fetch** (backend runs at `http://localhost:8080`).
 
+## Record a frontend demo
+
+You can capture a short video that demonstrates the frontend changes without
+starting the backend. The recorder spins up a temporary static file server,
+mocks the `/uv` API response with bundled sample data, and saves a WebM video.
+
+```bash
+pip install playwright
+playwright install chromium
+python scripts/record_demo.py --output demo/uv-index-demo.webm
+```
+
+The script writes the clip to the `demo/` directory by default; pass a
+different `--output` path if you prefer another location or filename.
+
 ## Docker
 
 ```bash

--- a/frontend/demo-data.json
+++ b/frontend/demo-data.json
@@ -1,0 +1,156 @@
+{
+  "lat": 37.1882,
+  "lon": -3.6067,
+  "date": "2024-09-22",
+  "tz": "Europe/Madrid",
+  "now_local_iso": "2024-09-22T10:30:00",
+  "now_bucket_time": "2024-09-22T10:00:00",
+  "hourly": [
+    {
+      "time": "2024-09-22T08:00:00",
+      "consensus": 1.4,
+      "low": 1.0,
+      "high": 1.8,
+      "providers": {
+        "OpenWeather": 1.3,
+        "VisualCrossing": 1.6,
+        "OpenUV": 1.4
+      },
+      "outliers": []
+    },
+    {
+      "time": "2024-09-22T09:00:00",
+      "consensus": 2.9,
+      "low": 2.5,
+      "high": 3.3,
+      "providers": {
+        "OpenWeather": 2.4,
+        "VisualCrossing": 3.2,
+        "OpenUV": 3.0
+      },
+      "outliers": ["OpenWeather"]
+    },
+    {
+      "time": "2024-09-22T10:00:00",
+      "consensus": 4.6,
+      "low": 4.1,
+      "high": 5.1,
+      "providers": {
+        "OpenWeather": 4.2,
+        "VisualCrossing": 4.9,
+        "OpenUV": 4.8
+      },
+      "outliers": []
+    },
+    {
+      "time": "2024-09-22T11:00:00",
+      "consensus": 6.8,
+      "low": 6.3,
+      "high": 7.2,
+      "providers": {
+        "OpenWeather": 6.1,
+        "VisualCrossing": 7.0,
+        "OpenUV": 7.3
+      },
+      "outliers": ["OpenWeather"]
+    },
+    {
+      "time": "2024-09-22T12:00:00",
+      "consensus": 8.1,
+      "low": 7.6,
+      "high": 8.7,
+      "providers": {
+        "OpenWeather": 8.2,
+        "VisualCrossing": 8.1,
+        "OpenUV": 8.7
+      },
+      "outliers": []
+    },
+    {
+      "time": "2024-09-22T13:00:00",
+      "consensus": 7.5,
+      "low": 7.0,
+      "high": 7.9,
+      "providers": {
+        "OpenWeather": 7.3,
+        "VisualCrossing": 7.4,
+        "OpenUV": 7.8
+      },
+      "outliers": []
+    },
+    {
+      "time": "2024-09-22T14:00:00",
+      "consensus": 5.2,
+      "low": 4.8,
+      "high": 5.7,
+      "providers": {
+        "OpenWeather": 4.9,
+        "VisualCrossing": 5.5,
+        "OpenUV": 5.2
+      },
+      "outliers": []
+    },
+    {
+      "time": "2024-09-22T15:00:00",
+      "consensus": 3.1,
+      "low": 2.7,
+      "high": 3.6,
+      "providers": {
+        "OpenWeather": 2.9,
+        "VisualCrossing": 3.3,
+        "OpenUV": 3.2
+      },
+      "outliers": []
+    },
+    {
+      "time": "2024-09-22T16:00:00",
+      "consensus": 1.8,
+      "low": 1.4,
+      "high": 2.1,
+      "providers": {
+        "OpenWeather": 1.5,
+        "VisualCrossing": 1.9,
+        "OpenUV": 1.8
+      },
+      "outliers": []
+    }
+  ],
+  "summary": {
+    "uv_max": 8.1,
+    "uv_max_time": "2024-09-22T12:00:00",
+    "advice": [
+      "Apply SPF 50+ sunscreen",
+      "Seek shade between 11:00 and 16:00",
+      "Wear sunglasses and a hat"
+    ],
+    "windows": {
+      "best": [
+        {
+          "start": "2024-09-22T07:00:00",
+          "end": "2024-09-22T09:00:00"
+        }
+      ],
+      "moderate": [
+        {
+          "start": "2024-09-22T09:00:00",
+          "end": "2024-09-22T11:00:00"
+        },
+        {
+          "start": "2024-09-22T16:00:00",
+          "end": "2024-09-22T18:00:00"
+        }
+      ],
+      "avoid": [
+        {
+          "start": "2024-09-22T11:00:00",
+          "end": "2024-09-22T15:00:00"
+        }
+      ]
+    }
+  },
+  "providers": [
+    {"name": "OpenWeather", "error": null},
+    {"name": "VisualCrossing", "error": null},
+    {"name": "OpenUV", "error": null}
+  ]
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -91,13 +91,280 @@
   </main>
 
   <script>
-    // Optimized and minified JavaScript for better performance
-    function checkLibs(){return typeof Plotly!=='undefined'&&typeof htmx!=='undefined'}
-    function waitLibs(){return new Promise(r=>{if(checkLibs()){r();return}const i=setInterval(()=>{if(checkLibs()){clearInterval(i);r()}},50);setTimeout(()=>{clearInterval(i);r()},5000)})}
-    function fetchData(){const lat=document.getElementById('lat').value,lon=document.getElementById('lon').value,date=document.getElementById('date').value,tz=document.getElementById('tz').value,qs=new URLSearchParams({lat,lon});if(date)qs.set('date',date);if(tz)qs.set('tz',tz);const result=document.getElementById('result'),loadingDiv=document.createElement('div');loadingDiv.setAttribute('role','status');loadingDiv.setAttribute('aria-live','polite');loadingDiv.setAttribute('aria-label','Loading UV data');loadingDiv.style.cssText='padding:20px;text-align:center;color:#6c757d';loadingDiv.textContent='Loading UV data...';result.innerHTML='';result.appendChild(loadingDiv);result.style.display='block';fetch('http://localhost:8080/uv?'+qs.toString()).then(r=>r.json()).then(draw).catch(err=>{const errorDiv=document.createElement('div');errorDiv.setAttribute('role','alert');errorDiv.setAttribute('aria-live','assertive');errorDiv.style.cssText='color:#dc3545;padding:12px;border:1px solid #f5c6cb;background-color:#f8d7da;border-radius:4px;margin-top:12px';errorDiv.textContent='Error fetching UV data: '+err;result.innerHTML='';result.appendChild(errorDiv);result.style.display='block'})}
-    function fmtTime(s){if(!s)return '';const t=s.replace('T',' ').replace(/:00:00$/,':00');return t.length>16?t.slice(0,16):t}
-    async function draw(data){await waitLibs();if(typeof Plotly==='undefined'){console.error('Plotly failed to load');document.getElementById('chart').innerHTML='<p style="color: #dc3545;">Chart library failed to load. Please refresh the page.</p>';return}const times=data.hourly.map(h=>h.time),consensus=data.hourly.map(h=>h.consensus),low=data.hourly.map(h=>h.low),high=data.hourly.map(h=>h.high),traces=[];traces.push({x:times.concat(times.slice().reverse()),y:high.concat(low.slice().reverse()),name:'Confidence band',fill:'tozeroy',mode:'lines',line:{width:0},hoverinfo:'skip',opacity:0.2});traces.push({x:times,y:consensus,name:'Consensus (median)',mode:'lines+markers',line:{width:2}});const providerSet=new Set();data.hourly.forEach(h=>{Object.keys(h.providers||{}).forEach(k=>providerSet.add(k))});providerSet.forEach(name=>{const y=data.hourly.map(h=>(h.providers&&h.providers[name]!==undefined)?h.providers[name]:null);traces.push({x:times,y,name,mode:'lines',line:{width:1}})});providerSet.forEach(name=>{const y=data.hourly.map(h=>(h.outliers&&h.outliers.includes(name))?h.providers[name]:null);traces.push({x:times,y,name:name+' outlier',mode:'markers',marker:{size:6,symbol:'x'},showlegend:false})});const shapes=[];if(data.now_bucket_time){shapes.push({type:'line',xref:'x',yref:'paper',x0:data.now_bucket_time,x1:data.now_bucket_time,y0:0,y1:1,line:{width:2,dash:'dot'}})}Plotly.newPlot('chart',traces,{title:`UV Index for ${data.date} @ (${data.lat.toFixed(4)}, ${data.lon.toFixed(4)}) [${data.tz}]`,yaxis:{title:'UV Index',rangemode:'tozero'},xaxis:{title:'Time'},margin:{t:50,r:20,b:50,l:50},shapes});document.getElementById('result').style.display='block';const s=data.summary||{},best=(s.windows&&s.windows.best)?s.windows.best:[],moderate=(s.windows&&s.windows.moderate)?s.windows.moderate:[],avoid=(s.windows&&s.windows.avoid)?s.windows.avoid:[];function renderIntervals(arr){if(!arr||!arr.length)return '<i>None</i>';return '<ul>'+arr.map(w=>`<li>${fmtTime(w.start)} → ${fmtTime(w.end)}</li>`).join('')+'</ul>'}const adviceList=(s.advice||[]).map(a=>`<li>${a}</li>`).join('');document.getElementById('summary').innerHTML=`<h2>UV Index Summary</h2><div><span class="k">Now:</span> ${fmtTime(data.now_local_iso)} (${data.tz})</div><div><span class="k">Peak UV:</span> ${s.uv_max??'–'} at ${fmtTime(s.uv_max_time)}</div><h3 style="margin-top:12px; margin-bottom:6px;">SPF & Sun Safety</h3><ul>${adviceList||'<li><i>No advice (no data)</i></li>'}</ul><h3 style="margin-top:12px; margin-bottom:6px;">Exposure Windows</h3><div><strong>Best</strong> (UV < 3): ${renderIntervals(best)}</div><div><strong>Moderate</strong> (3 ≤ UV < 6): ${renderIntervals(moderate)}</div><div><strong>Avoid</strong> (UV ≥ 8): ${renderIntervals(avoid)}</div>`;const meta=(data.providers||[]).map(p=>{if(p.error)return `<li><b>${p.name}</b>: <i>${p.error}</i></li>`;return `<li><b>${p.name}</b>: OK</li>`}).join('');document.getElementById('providers').innerHTML=`<h2>Data Providers</h2><ul>${meta}</ul><p class="meta">Tip: leave <code>Timezone</code> as <code>auto</code> for automatic detection based on coordinates.</p>`}
-    document.addEventListener('DOMContentLoaded',function(){const form=document.querySelector('form');form.addEventListener('submit',function(e){e.preventDefault();fetchData()});const today=new Date().toISOString().split('T')[0];document.getElementById('date').value=today;if('serviceWorker'in navigator){navigator.serviceWorker.register('/sw.js')}});
+    function checkLibs() {
+      return typeof Plotly !== 'undefined' && typeof htmx !== 'undefined';
+    }
+
+    function waitLibs() {
+      return new Promise((resolve) => {
+        if (checkLibs()) {
+          resolve();
+          return;
+        }
+
+        const interval = setInterval(() => {
+          if (checkLibs()) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 50);
+
+        setTimeout(() => {
+          clearInterval(interval);
+          resolve();
+        }, 5000);
+      });
+    }
+
+    function getUiSections() {
+      const result = document.getElementById('result');
+      const chart = document.getElementById('chart');
+      const summary = document.getElementById('summary');
+      const providers = document.getElementById('providers');
+      return { result, chart, summary, providers };
+    }
+
+    function showLoadingState() {
+      const { result, chart, summary, providers } = getUiSections();
+      if (!result || !chart || !summary || !providers) {
+        return;
+      }
+
+      const loading = document.createElement('div');
+      loading.setAttribute('role', 'status');
+      loading.setAttribute('aria-live', 'polite');
+      loading.setAttribute('aria-label', 'Loading UV data');
+      loading.style.cssText =
+        'padding:20px;text-align:center;color:#6c757d;font-weight:500;';
+      loading.textContent = 'Loading UV data…';
+
+      chart.innerHTML = '';
+      chart.appendChild(loading);
+      summary.innerHTML = '';
+      providers.innerHTML = '';
+      result.style.display = 'block';
+    }
+
+    function showErrorState(message) {
+      const { result, chart, summary, providers } = getUiSections();
+      if (!result || !chart || !summary || !providers) {
+        return;
+      }
+
+      const error = document.createElement('div');
+      error.setAttribute('role', 'alert');
+      error.setAttribute('aria-live', 'assertive');
+      error.style.cssText =
+        'color:#dc3545;padding:12px;border:1px solid #f5c6cb;background-color:#f8d7da;border-radius:4px;margin-top:12px;font-weight:500;';
+      error.textContent = message;
+
+      chart.innerHTML = '';
+      chart.appendChild(error);
+      summary.innerHTML = '';
+      providers.innerHTML = '';
+      result.style.display = 'block';
+    }
+
+    function fetchData() {
+      const lat = document.getElementById('lat').value;
+      const lon = document.getElementById('lon').value;
+      const date = document.getElementById('date').value;
+      const tz = document.getElementById('tz').value;
+
+      const params = new URLSearchParams({ lat, lon });
+      if (date) params.set('date', date);
+      if (tz) params.set('tz', tz);
+
+      showLoadingState();
+
+      fetch(`http://localhost:8080/uv?${params.toString()}`)
+        .then((response) => response.json())
+        .then(draw)
+        .catch((err) => {
+          console.error('Error fetching UV data', err);
+          showErrorState(`Error fetching UV data: ${err}`);
+        });
+    }
+
+    function fmtTime(s) {
+      if (!s) return '';
+      const t = s.replace('T', ' ').replace(/:00:00$/, ':00');
+      return t.length > 16 ? t.slice(0, 16) : t;
+    }
+
+    function buildProviderSet(data) {
+      const names = new Set((data.providers || []).map((p) => p.name));
+      data.hourly.forEach((h) => {
+        Object.keys(h.providers || {}).forEach((key) => names.add(key));
+      });
+      return names;
+    }
+
+    function renderIntervals(arr) {
+      if (!arr || !arr.length) return '<i>None</i>';
+      return (
+        '<ul>' +
+        arr
+          .map((w) => `<li>${fmtTime(w.start)} → ${fmtTime(w.end)}</li>`)
+          .join('') +
+        '</ul>'
+      );
+    }
+
+    async function draw(data) {
+      await waitLibs();
+      const { result, chart, summary, providers } = getUiSections();
+
+      if (!chart || !summary || !providers || !result) {
+        console.error('Missing UI containers for rendering');
+        return;
+      }
+
+      if (typeof Plotly === 'undefined') {
+        console.error('Plotly failed to load');
+        showErrorState('Chart library failed to load. Please refresh the page.');
+        return;
+      }
+
+      const times = data.hourly.map((h) => h.time);
+      const consensus = data.hourly.map((h) => h.consensus);
+      const low = data.hourly.map((h) => h.low);
+      const high = data.hourly.map((h) => h.high);
+      const traces = [];
+
+      if (times.length) {
+        traces.push({
+          x: times.concat(times.slice().reverse()),
+          y: high.concat(low.slice().reverse()),
+          name: 'Confidence band',
+          fill: 'tozeroy',
+          mode: 'lines',
+          line: { width: 0 },
+          hoverinfo: 'skip',
+          opacity: 0.2,
+        });
+      }
+
+      traces.push({
+        x: times,
+        y: consensus,
+        name: 'Consensus (median)',
+        mode: 'lines+markers',
+        line: { width: 2 },
+        marker: { size: 6 },
+      });
+
+      const providerSet = buildProviderSet(data);
+      providerSet.forEach((name) => {
+        const y = data.hourly.map((h) =>
+          h.providers && h.providers[name] !== undefined ? h.providers[name] : null,
+        );
+        traces.push({
+          x: times,
+          y,
+          name,
+          mode: 'lines+markers',
+          line: { width: 1 },
+          marker: { size: 5 },
+        });
+      });
+
+      providerSet.forEach((name) => {
+        const y = data.hourly.map((h) =>
+          h.outliers && h.outliers.includes(name) ? h.providers[name] : null,
+        );
+        traces.push({
+          x: times,
+          y,
+          name: `${name} outlier`,
+          mode: 'markers',
+          marker: { size: 7, symbol: 'x' },
+          showlegend: false,
+        });
+      });
+
+      const shapes = [];
+      if (data.now_bucket_time) {
+        shapes.push({
+          type: 'line',
+          xref: 'x',
+          yref: 'paper',
+          x0: data.now_bucket_time,
+          x1: data.now_bucket_time,
+          y0: 0,
+          y1: 1,
+          line: { width: 2, dash: 'dot' },
+        });
+      }
+
+      Plotly.react(
+        chart,
+        traces,
+        {
+          title: `UV Index for ${data.date} @ (${data.lat.toFixed(4)}, ${data.lon.toFixed(4)}) [${data.tz}]`,
+          yaxis: { title: 'UV Index', rangemode: 'tozero' },
+          xaxis: { title: 'Time' },
+          margin: { t: 50, r: 20, b: 50, l: 50 },
+          shapes,
+          hovermode: 'x unified',
+        },
+        { displaylogo: false, responsive: true },
+      );
+
+      result.style.display = 'block';
+
+      const summaryData = data.summary || {};
+      const best = summaryData.windows && summaryData.windows.best ? summaryData.windows.best : [];
+      const moderate =
+        summaryData.windows && summaryData.windows.moderate ? summaryData.windows.moderate : [];
+      const avoid = summaryData.windows && summaryData.windows.avoid ? summaryData.windows.avoid : [];
+
+      const adviceList = (summaryData.advice || [])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+
+      summary.innerHTML = `
+        <h2>UV Index Summary</h2>
+        <div><span class="k">Now:</span> ${fmtTime(data.now_local_iso)} (${data.tz})</div>
+        <div><span class="k">Peak UV:</span> ${summaryData.uv_max ?? '–'} at ${fmtTime(summaryData.uv_max_time)}</div>
+        <h3 style="margin-top:12px; margin-bottom:6px;">SPF & Sun Safety</h3>
+        <ul>${adviceList || '<li><i>No advice (no data)</i></li>'}</ul>
+        <h3 style="margin-top:12px; margin-bottom:6px;">Exposure Windows</h3>
+        <div><strong>Best</strong> (UV < 3): ${renderIntervals(best)}</div>
+        <div><strong>Moderate</strong> (3 ≤ UV < 6): ${renderIntervals(moderate)}</div>
+        <div><strong>Avoid</strong> (UV ≥ 8): ${renderIntervals(avoid)}</div>
+      `;
+
+      const meta = (data.providers || [])
+        .map((p) => {
+          if (p.error) {
+            return `<li><b>${p.name}</b>: <i>${p.error}</i></li>`;
+          }
+          return `<li><b>${p.name}</b>: OK</li>`;
+        })
+        .join('');
+
+      providers.innerHTML = `
+        <h2>Data Providers</h2>
+        <ul>${meta}</ul>
+        <p class="meta">Tip: leave <code>Timezone</code> as <code>auto</code> for automatic detection based on coordinates.</p>
+      `;
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+      const form = document.querySelector('form');
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
+        fetchData();
+      });
+
+      const today = new Date().toISOString().split('T')[0];
+      document.getElementById('date').value = today;
+
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('/sw.js');
+      }
+    });
   </script>
 </body>
 </html>

--- a/scripts/record_demo.py
+++ b/scripts/record_demo.py
@@ -1,0 +1,140 @@
+"""Record a short demo video of the UV Index frontend with mocked data.
+
+This script uses Playwright to open the static frontend, intercept the
+API request for UV data, and render the graph using a bundled demo JSON
+payload. The browser session records a video that can be shared with
+testers or stakeholders.
+
+Example:
+    python scripts/record_demo.py --output demo/session.webm
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import socketserver
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler
+from pathlib import Path
+from typing import Optional
+
+from playwright.async_api import Playwright, async_playwright
+
+
+class ThreadingHTTPServer(socketserver.ThreadingTCPServer):
+    """Threading HTTP server with address reuse enabled."""
+
+    allow_reuse_address = True
+
+
+class FrontendServer(contextlib.AbstractAsyncContextManager):
+    """Serve the static frontend directory during the demo run."""
+
+    def __init__(self, directory: Path, port: int = 0) -> None:
+        self._directory = directory
+        self._port = port
+        self._httpd: Optional[ThreadingHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    async def __aenter__(self) -> "FrontendServer":
+        handler = partial(SimpleHTTPRequestHandler, directory=str(self._directory))
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", self._port), handler)
+        self._port = self._httpd.server_address[1]
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        if self._httpd:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+        if self._thread:
+            self._thread.join(timeout=5)
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self._port}/index.html"
+
+
+async def record_demo(
+    playwright: Playwright, data_path: Path, output: Path, duration: int
+) -> Path:
+    frontend_dir = Path(__file__).parent.parent / "frontend"
+
+    async with FrontendServer(frontend_dir) as server:
+        browser = await playwright.chromium.launch(headless=True)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        context = await browser.new_context(record_video_dir=str(output.parent))
+        page = await context.new_page()
+
+        demo_payload = json.loads(data_path.read_text(encoding="utf-8"))
+
+        async def fulfill_demo(route):
+            await route.fulfill(
+                content_type="application/json", body=json.dumps(demo_payload)
+            )
+
+        await page.route("**/uv?*", fulfill_demo)
+
+        await page.goto(server.url)
+        await page.wait_for_load_state("domcontentloaded")
+
+        await page.fill("#lat", f"{demo_payload['lat']:.4f}")
+        await page.fill("#lon", f"{demo_payload['lon']:.4f}")
+        await page.fill("#date", demo_payload.get("date", ""))
+        await page.fill("#tz", demo_payload.get("tz", ""))
+        await page.click("#go")
+
+        await page.wait_for_selector("text=Data Providers", timeout=10000)
+        await page.wait_for_timeout(duration)
+
+        video_relative = await page.video.path() if page.video else None
+        await context.close()
+        await browser.close()
+
+    if not video_relative:
+        raise RuntimeError("Playwright did not record a video for the session")
+
+    video_path = Path(video_relative)
+    final_path = output.with_suffix(output.suffix or video_path.suffix)
+    video_path.rename(final_path)
+    return final_path
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Record a demo run of the UV Index frontend."
+    )
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=Path("frontend/demo-data.json"),
+        help="Path to the demo JSON payload used to mock the API response.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("demo/uv-index-demo.webm"),
+        help="Where to write the recorded video.",
+    )
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=2000,
+        help="Additional milliseconds to wait after the chart is rendered before closing.",
+    )
+    args = parser.parse_args()
+
+    async with async_playwright() as playwright:
+        video_path = await record_demo(
+            playwright, args.data, args.output, args.duration
+        )
+    print(f"Demo recorded to {video_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Summary: Add a Playwright-powered script plus sample data to record a frontend demo video without needing the live backend, and document how to run it.

Testing Done:
- pytest tests (fails: pytest does not recognize --asyncio-mode=auto from repo config)
- ruff check (fails: existing lint errors in legacy debug/tests modules)


------
https://chatgpt.com/codex/tasks/task_e_68dd23c3a0e08330afb667c7141db4b7